### PR TITLE
Add Attribute.create_many to create multiple attributes in a single changeset

### DIFF
--- a/mstrio/__init__.py
+++ b/mstrio/__init__.py
@@ -22,9 +22,9 @@ administrators to leverage the power of Python to address complex
 administrative workflows for maintaining a MicroStrategy environment.
 """
 
-__title__ = "mstrio-py"
-__version__ = "11.5.2.101"  # NOSONAR
+__title__ = "ni-mstrio-py"
+__version__ = "2025.0.0"  # NOSONAR
 __license__ = "Apache License 2.0"
-__description__ = "Python interface for the MicroStrategy REST API"
-__author__ = "MicroStrategy"
-__author_email__ = "bkaczynski@microstrategy.com"
+__description__ = "NI-customized Python interface for the MicroStrategy REST API"
+__author__ = "NI"
+__author_email__ = "robert.szarvas@emerson.com"

--- a/mstrio/api/attributes.py
+++ b/mstrio/api/attributes.py
@@ -38,7 +38,8 @@ def create_attribute(
             Only 'acl' is supported.
         fields: A whitelist of top-level fields separated by commas.
             Allow the client to selectively retrieve fields in the response.
-        changeset_id: 
+        changeset_id: Specifies an existing changeset ID. If omitted, a new
+            changeset is created.
 
     Return:
         HTTP response object. Expected status: 201
@@ -62,25 +63,9 @@ def create_attributes(
 
     Args:
         connection: MicroStrategy REST API connection object
-        bodies: List of attribute creation data
-        show_expression_as: Specifies the format in which the expressions are
-           returned in response
-           Available values: 'tokens', 'tree'
-           If omitted, the expression is returned in 'text' format
-           If 'tree', the expression is returned in 'text' and 'tree' formats.
-           If 'tokens', the expression is returned in 'text' and 'tokens'
-           formats.
-        show_potential_tables: Specifies whether to return the potential tables
-            that the expressions can be applied to.
-            Available values: 'true', 'false'
-            If 'true', the 'potentialTables' field returns for each attribute
-                expression, in the form of a list of tables.
-            If 'false' or omitted, the 'potentialTables' field is omitted.
-        show_fields: Specifies what additional information to return.
-            Only 'acl' is supported.
-        fields: A whitelist of top-level fields separated by commas.
-            Allow the client to selectively retrieve fields in the response.
-        changeset_id: 
+        create_attribute_dtos: List of attribute creation data
+        changeset_id: Specifies an existing changeset ID. If omitted, a new
+            changeset is created.
 
     Return:
         HTTP response object. Expected status: 201

--- a/mstrio/api/attributes.py
+++ b/mstrio/api/attributes.py
@@ -1,5 +1,6 @@
 from mstrio.connection import Connection
 from mstrio.utils.api_helpers import changeset_manager, unpack_information
+from mstrio.utils.dtos.create_attribute_dto import CreateAttributeDto
 from mstrio.utils.error_handlers import ErrorHandler
 
 
@@ -12,6 +13,7 @@ def create_attribute(
     show_potential_tables: str | None = None,
     show_fields: str | None = None,
     fields: str | None = None,
+    changeset_id: str | None = None
 ):
     """Create a new attribute in the changeset,
     based on the definition provided in request body.
@@ -36,22 +38,89 @@ def create_attribute(
             Only 'acl' is supported.
         fields: A whitelist of top-level fields separated by commas.
             Allow the client to selectively retrieve fields in the response.
+        changeset_id: 
 
     Return:
         HTTP response object. Expected status: 201
     """
-    with changeset_manager(connection) as changeset_id:
-        return connection.post(
-            endpoint='/api/model/attributes',
-            headers={'X-MSTR-MS-Changeset': changeset_id},
-            params={
-                'showExpressionAs': show_expression_as,
-                'showPotentialTables': show_potential_tables,
-                'showFields': show_fields,
-                'fields': fields,
-            },
-            json=body,
-        )
+    if not changeset_id:
+        with changeset_manager(connection) as changeset_id:
+            return _create_attribute(connection, body, changeset_id, show_expression_as, show_potential_tables, show_fields, fields)
+
+    return _create_attribute(connection, body, changeset_id, show_expression_as, show_potential_tables, show_fields, fields)
+
+   
+@unpack_information
+# @ErrorHandler(err_msg="Error creating an attribute")
+def create_attributes(
+    connection: Connection,
+    create_attribute_dtos: list[CreateAttributeDto],
+    changeset_id: str | None = None
+):
+    """Create multiple attributes in the changeset,
+    based on the definitions provided in request bodies.
+
+    Args:
+        connection: MicroStrategy REST API connection object
+        bodies: List of attribute creation data
+        show_expression_as: Specifies the format in which the expressions are
+           returned in response
+           Available values: 'tokens', 'tree'
+           If omitted, the expression is returned in 'text' format
+           If 'tree', the expression is returned in 'text' and 'tree' formats.
+           If 'tokens', the expression is returned in 'text' and 'tokens'
+           formats.
+        show_potential_tables: Specifies whether to return the potential tables
+            that the expressions can be applied to.
+            Available values: 'true', 'false'
+            If 'true', the 'potentialTables' field returns for each attribute
+                expression, in the form of a list of tables.
+            If 'false' or omitted, the 'potentialTables' field is omitted.
+        show_fields: Specifies what additional information to return.
+            Only 'acl' is supported.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        changeset_id: 
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if not changeset_id:
+        with changeset_manager(connection) as changeset_id:
+            responses = [_create_attribute(connection, create_attribute_dto.body, changeset_id,
+                                           create_attribute_dto.show_expression_as, create_attribute_dto.show_potential_tables,
+                                           create_attribute_dto.show_fields, create_attribute_dto.fields)
+                         for create_attribute_dto in create_attribute_dtos]
+            return responses
+        
+    responses = [_create_attribute(connection, create_attribute_dto.body, changeset_id,
+                                   create_attribute_dto.show_expression_as, create_attribute_dto.show_potential_tables,
+                                   create_attribute_dto.show_fields, create_attribute_dto.fields)
+                 for create_attribute_dto in create_attribute_dtos]
+    return responses
+
+
+def _create_attribute(
+    connection: Connection,
+    body: dict,
+    changeset_id: str,
+    show_expression_as: list[str] | None = None,
+    show_potential_tables: str | None = None,
+    show_fields: str | None = None,
+    fields: str | None = None,
+):
+    """Helper function to create a single attribute."""
+    return connection.post(
+        endpoint='/api/model/attributes',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'showExpressionAs': show_expression_as,
+            'showPotentialTables': show_potential_tables,
+            'showFields': show_fields,
+            'fields': fields,
+        },
+        json=body,
+    )
 
 
 @unpack_information

--- a/mstrio/modeling/schema/attribute/attribute.py
+++ b/mstrio/modeling/schema/attribute/attribute.py
@@ -455,6 +455,15 @@ class Attribute(Entity, CopyMixin, MoveMixin, DeleteMixin):  # noqa
         connection: 'Connection',
         attributes_data: list[AttributeData],
     ) -> list['Attribute']:
+        """ Create multiple attributes at once.
+
+        Args:
+            connection: MicroStrategy connection object returned
+                by `connection.Connection()`
+            attributes_data: list of AttributeData objects
+        Returns:
+            Attribute class object.
+        """
         create_attribute_dtos = [
             cls._attribute_data_to_create_attribute_dto(attribute_data)
             for attribute_data in attributes_data

--- a/mstrio/modeling/schema/attribute/attribute_data.py
+++ b/mstrio/modeling/schema/attribute/attribute_data.py
@@ -7,6 +7,41 @@ from mstrio.object_management.folder import Folder
 
 @dataclass
 class AttributeData:
+    """Create data object for creating an attribute
+
+    Args:
+        name: attribute's name
+        sub_type: attribute's sub_type
+        destination_folder: A globally unique identifier used to
+            distinguish between metadata objects within the same project.
+            It is possible for two metadata objects in different projects
+            to have the same Object ID.
+        forms: attribute's forms list
+        key_form: a key form of an attribute
+        displays: The collections of attribute displays and browse displays
+            of the attribute.
+        description: attribute's description
+        is_embedded: If true indicates that the target object of this
+            reference is embedded within this object. Alternatively if
+            this object is itself embedded, then it means that the target
+            object is embedded in the same container as this object.
+        attribute_lookup_table: Information about an object referenced
+            within the  specification of another object. An object reference
+            typically contains only enough fields to uniquely identify
+            the referenced objects.
+        sorts: The collections of attribute sorts and browse sorts
+            of the attribute.
+        show_expression_as (ExpressionFormat, str): specify how expressions
+            should be presented
+            Available values:
+            - `ExpressionFormat.TREE` or `tree` (default)
+            - `ExpressionFormat.TOKENS or `tokens`
+        hidden (bool, optional): Specifies whether the object is hidden.
+            Default value: False.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
     name: str
     sub_type: ObjectSubType | str
     destination_folder: Folder | str

--- a/mstrio/modeling/schema/attribute/attribute_data.py
+++ b/mstrio/modeling/schema/attribute/attribute_data.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from mstrio.modeling.expression.enums import ExpressionFormat
+from mstrio.modeling.schema.attribute.attribute_form import AttributeForm
+from mstrio.modeling.schema.helpers import AttributeDisplays, AttributeSorts, FormReference, ObjectSubType, SchemaObjectReference
+from mstrio.object_management.folder import Folder
+
+
+@dataclass
+class AttributeData:
+    name: str
+    sub_type: ObjectSubType | str
+    destination_folder: Folder | str
+    forms: list[AttributeForm]
+    key_form: FormReference
+    displays: AttributeDisplays
+    description: str | None = None
+    is_embedded: bool = False
+    attribute_lookup_table: SchemaObjectReference | None = None
+    sorts: AttributeSorts | None = None
+    show_expression_as: ExpressionFormat | str = ExpressionFormat.TREE.value
+    hidden: bool | None = None

--- a/mstrio/utils/dtos/create_attribute_dto.py
+++ b/mstrio/utils/dtos/create_attribute_dto.py
@@ -3,6 +3,29 @@ from dataclasses import dataclass
 
 @dataclass
 class CreateAttributeDto:
+    """ DTO for creating an attribute
+
+    Args:
+        bodies: List of attribute creation data
+        show_expression_as: Specifies the format in which the expressions are
+           returned in response
+           Available values: 'tokens', 'tree'
+           If omitted, the expression is returned in 'text' format
+           If 'tree', the expression is returned in 'text' and 'tree' formats.
+           If 'tokens', the expression is returned in 'text' and 'tokens'
+           formats.
+        show_potential_tables: Specifies whether to return the potential tables
+            that the expressions can be applied to.
+            Available values: 'true', 'false'
+            If 'true', the 'potentialTables' field returns for each attribute
+                expression, in the form of a list of tables.
+            If 'false' or omitted, the 'potentialTables' field is omitted.
+        show_fields: Specifies what additional information to return.
+            Only 'acl' is supported.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        changeset_id: 
+    """
     body: dict
     show_expression_as: list[str] | None = None
     show_potential_tables: str | None = None

--- a/mstrio/utils/dtos/create_attribute_dto.py
+++ b/mstrio/utils/dtos/create_attribute_dto.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class CreateAttributeDto:
+    body: dict
+    show_expression_as: list[str] | None = None
+    show_potential_tables: str | None = None
+    show_fields: str | None = None
+    fields: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = [
 packages = ["mstrio"]
 
 [project]
-name = "mstrio-py"
+name = "ni-mstrio-py"
 description = "Python interface for the MicroStrategy REST API"
 authors = [{ name = "MicroStrategy", email = "bkaczynski@microstrategy.com" }]
 requires-python = ">=3.10,<3.14"


### PR DESCRIPTION
# Implementation

The functionality of creating an attribute in a single changeset is introduced by this PR. The added functionality supports unpacking responses into object, so that we achieve the same capability MSTR originally provides.

The code was refactored so that we avoid code duplication. Existing "API-like" code was left untouched for backwards compatibility reasons. The only change is an addition of the `changeset_id` parameter, which would allow the consumer of the existing method to manage the changeset on their own.

Unlike the existing methods, the new one factorizes parameters into objects (`AttributeData` and `CreateAttributeDto`)

The performance improvement is 5x:
![image](https://github.com/user-attachments/assets/44bbd68f-782c-41b5-8250-7590cc57341e)


TODO: Handle error cases. Only happy flow is handled here. 